### PR TITLE
fix: remove playground-showcase from changeset ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,6 @@
   "ignore": [
     "@nullshot/mcp-toolbox",
     "@nullshot/mcp-proxy",
-    "@nullshot/playground",
-    "playground-showcase"
+    "@nullshot/playground"
   ]
 }


### PR DESCRIPTION
## Problem

The changeset validation is failing with this error:
```
🦋 error ValidationError: The package or glob expression "playground-showcase" is specified in the ignore option but it is not found in the project.
```

## Root Cause

In PR #72, we incorrectly added `playground-showcase` to the changeset ignore list, but this package cannot be found by changeset validation.

## Solution

- Remove `"playground-showcase"` from the ignore list in `.changeset/config.json`
- This follows GitHub Copilot's recommendation
- Since `playground-showcase` is a private package that depends on `@nullshot/playground` (already ignored), removing it is safe

## Result

- ✅ Fixes changeset validation errors
- ✅ Allows release pipeline to work correctly
- ✅ Resolves the failing release checks

This is a critical fix to unblock releases.